### PR TITLE
Use git instead of npm #2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cjdns"]
 	path = cjdns
 	url = https://github.com/cjdelisle/cjdns.git
+[submodule "peers"]
+	path = peers
+	url = https://github.com/hyperboria/peers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,3 @@ sudo: enabled
 os: linux
 script:
 - ./build.sh
-deploy:
-    provider: pages
-    skip_cleanup: true
-    github-token: $GITHUB_TOKEN
-    local-dir: out

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ sudo: enabled
 os: linux
 script:
 - ./build.sh
+deploy:
+    provider: pages
+    skip_cleanup: true
+    github-token: $GITHUB_TOKEN
+    local-dir: out

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,10 @@ die() { echo "$*" 1>&2 ; exit 1; }
 
 node --version
 
+## pull latest commits of cjdns and hyperboria-peers
+
+git submodule update --recursive --remote
+
 pushd cjdns
 ./do || die "[-] Build failed";
 popd

--- a/main
+++ b/main
@@ -13,7 +13,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-var Peers = require("hyperboria-peers");
+var Peers = require("./peers/index.js");
 var fs = require('fs');
 
 const getPeers = function () {

--- a/main
+++ b/main
@@ -21,12 +21,24 @@ const getPeers = function () {
         if (typeof creds.location !== 'undefined')
             delete creds.location;
 
-        for (const peer in creds)
-            if (creds.hasOwnProperty(peer))
-                if (peer.indexOf('[') === -1)
+        for (const peer in creds) {
+            if (creds.hasOwnProperty(peer)) {
+                // skip IPv6 peers, travis does not support this
+                if (peer.indexOf('[') === -1) {
+                    // clear optional fields (see hyperboria/peers#126 or hyperboria/peers#/128)
+                    optfields = ['contact', 'gpg', 'ipv6', 'location'];
+
+                    for (const i in optfields) {
+                        if (typeof(creds[peer][optfields[i]]) !== 'undefined')
+                            delete creds[peer][optfields[i]];
+                    }
+
                     return {
                         [peer]: creds[peer]
                     };
+                }
+            }
+        }
     });
 }
 


### PR DESCRIPTION
Now uses git submodules to pull latest version of:

* cjdns
* hyperboria/peers

The submodule pointers are irrelevant, a remote update is initiated upon **Travis CI** builds.